### PR TITLE
Adding Description to the Team object

### DIFF
--- a/team/team.go
+++ b/team/team.go
@@ -16,6 +16,7 @@ type Member struct {
 // CreateTeamRequest provides necessary parameter structure for creating team
 type CreateTeamRequest struct {
 	APIKey string `json:"apiKey,omitempty"`
+	Description string `json:"description,omitempty"`
 	Name   string `json:"name,omitempty"`
         Members []Member `json:"members,omitempty"`
 }
@@ -23,6 +24,7 @@ type CreateTeamRequest struct {
 // UpdateTeamRequest provides necessary parameter structure for updating a team
 type UpdateTeamRequest struct {
 	APIKey string `json:"apiKey,omitempty"`
+	Description string `json:"description,omitempty"`
 	Id     string `json:"id,omitempty"`
         Name   string `json:"name,omitempty"`
         Members []Member `json:"members,omitempty"`

--- a/team/team_responses.go
+++ b/team/team_responses.go
@@ -21,6 +21,7 @@ type DeleteTeamResponse struct {
 
 // Get team response structure
 type GetTeamResponse struct {
+	Description string `json:"description,omitempty"`
 	Id string `json:"id,omitempty"`
 	Name string `json:"name,omitempty"`
 	Members []Member `json:"members,omitempty"`


### PR DESCRIPTION
Adding a missing `description` field described in the documentation for the [Teams API](https://www.opsgenie.com/docs/web-api/team-api#TeamRESTAPI-CreateTeamRequest)