### PR TITLE
Users: Support for SkypeUsername on Create/Get/Update

### DIFF
--- a/user/user.go
+++ b/user/user.go
@@ -14,6 +14,7 @@ type CreateUserRequest struct {
 	Fullname string `json:"fullname,omitempty"`
 	Role string `json:"role,omitempty"`
 	Locale string `json:"locale,omitempty"`
+	SkypeUsername string `json:"skypeUsername,omitempty"`
 	Timezone string `json:"timezone,omitempty"`
 }
 
@@ -24,6 +25,7 @@ type UpdateUserRequest struct {
 	Fullname string `json:"fullname,omitempty"`
 	Role string `json:"role,omitempty"`
 	Locale string `json:"locale,omitempty"`
+	SkypeUsername string `json:"skypeUsername,omitempty"`
 	Timezone string `json:"timezone,omitempty"`
 }
 

--- a/user/user_responses.go
+++ b/user/user_responses.go
@@ -10,13 +10,13 @@ type CreateUserResponse struct {
 // Update user response structure
 type UpdateUserResponse struct {
 	Status string `json:"status"`
-        Code int `json:"code"`
+  Code int `json:"code"`
 }
 
 // Delete user response structure
 type DeleteUserResponse struct {
 	Status string `json:"status"`
-        Code int `json:"code"`
+	Code int `json:"code"`
 }
 
 // Participant
@@ -30,6 +30,7 @@ type GetUserResponse struct {
 	Id string `json:"id,omitempty"`
 	Username string `json:"username,omitempty"`
 	Fullname string `json:"fullname,omitempty"`
+	SkypeUsername string `json:"skypeUsername,omitempty"`
 	Timezone string `json:"timezone,omitempty"`
 	Locale string `json:"locale,omitempty"`
 	State string `json:"state,omitempty"`


### PR DESCRIPTION
The [Documentation](https://www.opsgenie.com/docs/web-api/user-api) defines a field, `skypeUsername` available when Creating / Updating / Getting a user via the User API.

This PR exposes that field so it's usable in the SDK