### PR TITLE
Add responders field to create alert request for alertsv2

### DIFF
--- a/alertsv2/create_alert_request_test.go
+++ b/alertsv2/create_alert_request_test.go
@@ -1,0 +1,92 @@
+package alertsv2_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/opsgenie/opsgenie-go-sdk/alertsv2"
+)
+
+func TestCreateAlertRequest(t *testing.T) {
+
+	responders := []alertsv2.Recipient{
+		&alertsv2.Escalation{ID: "escalationId"},
+		&alertsv2.Escalation{Name: "escalationName"},
+		&alertsv2.Schedule{ID: "scheduleId"},
+		&alertsv2.Schedule{Name: "scheduleName"},
+		&alertsv2.Team{ID: "teamId"},
+		&alertsv2.Team{Name: "teamName"},
+		&alertsv2.User{ID: "userId"},
+		&alertsv2.User{Username: "user@opsgenie.com"},
+	}
+
+	visibleTo := []alertsv2.Recipient{
+		&alertsv2.Team{ID: "teamId"},
+		&alertsv2.Team{Name: "teamName"},
+		&alertsv2.User{ID: "userId"},
+		&alertsv2.User{Username: "user@opsgenie.com"},
+	}
+
+	createAlertRequest := alertsv2.CreateAlertRequest{
+		Message:     "message",
+		Alias:       "alias",
+		Description: "alert description",
+		Responders:  responders,
+		VisibleTo:   visibleTo,
+		Actions:     []string{"action1", "action2"},
+		Tags:        []string{"tag1", "tag2"},
+		Details: map[string]string{
+			"key":  "value",
+			"key2": "value2",
+		},
+		Entity:   "entity",
+		Source:   "source",
+		Priority: alertsv2.P1,
+		User:     "user@opsgenie.com",
+		Note:     "alert note",
+	}
+
+	createAlertRequest.Init()
+
+	type expectedFormat struct {
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		Username string `json:"username"`
+		Type     string `json:"type"`
+	}
+	expectations := []expectedFormat{
+		expectedFormat{Type: "escalation", ID: "escalationId"},
+		expectedFormat{Type: "escalation", Name: "escalationName"},
+		expectedFormat{Type: "schedule", ID: "scheduleId"},
+		expectedFormat{Type: "schedule", Name: "scheduleName"},
+		expectedFormat{Type: "team", ID: "teamId"},
+		expectedFormat{Type: "team", Name: "teamName"},
+		expectedFormat{Type: "user", ID: "userId"},
+		expectedFormat{Type: "user", Username: "user@opsgenie.com"},
+	}
+
+	for _, responder := range createAlertRequest.Responders {
+		// JSON marshal and unmarshal to ensure field names
+		responderJSON, _ := json.Marshal(responder)
+
+		var actualResponder expectedFormat
+		err := json.Unmarshal(responderJSON, &actualResponder)
+		if err != nil {
+			t.Error(err)
+			t.Fatal("Expected no error unmarshalling response, but there was one.")
+		}
+
+		var ok bool
+		for _, expectedResponder := range expectations {
+			if actualResponder == expectedResponder {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			t.Fatal("Expected to match responder, but it didn't")
+		}
+
+	}
+
+}

--- a/alertsv2/recipient.go
+++ b/alertsv2/recipient.go
@@ -50,6 +50,19 @@ type Escalation struct {
 	Name string `json:"name,omitempty"`
 }
 
+func (e *Escalation) SetID(id string) {
+	e.ID = id
+}
+
+type Schedule struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+func (s *Schedule) SetID(id string) {
+	s.ID = id
+}
+
 type RecipientDTO struct {
 	Id       string `json:"id,omitempty"`
 	Username string `json:"username,omitempty"`


### PR DESCRIPTION
According to the [API documentation](https://docs.opsgenie.com/docs/alert-api#section-create-alert) this SDK is missing the field `Responders`. 

This pull request adds the `Responders` field supporting entries for teams, users, escalations and schedules in the request to create an alert.  

Also based on the API docs the field `Teams` is no longer expected in the V2, for that reason I have removed from `alertsv2` package.