### PR TITLE
Note repo as unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # opsgenie-go-sdk
+
+<aside class="notice">
+This SDK is not actively maintained. Please consider generating a client from the [OpenAPI Spec](https://github.com/opsgenie/opsgenie-oas)
+</aside>
+
 ## Aim and Scope
 OpsGenie GO SDK aims to access OpsGenie Web API through HTTP calls
 from a client application purely written in Go language.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # opsgenie-go-sdk
 
-<aside class="notice">
-This SDK is not actively maintained. Please consider generating a client from the [OpenAPI Spec](https://github.com/opsgenie/opsgenie-oas)
-</aside>
+*This SDK is not actively maintained. Please consider generating a client from the [OpenAPI Spec](https://github.com/opsgenie/opsgenie-oas)*
 
 ## Aim and Scope
 OpsGenie GO SDK aims to access OpsGenie Web API through HTTP calls


### PR DESCRIPTION
As there is no active development or maintenance on this repository (i.e. Go`1.4.2` is significantly out of date, the current version as of writing is `1.12`) it should be marked as such to prevent any confusion from the user